### PR TITLE
Correct label for Restrict ITab

### DIFF
--- a/source/ITab/ITab_Restrict.cs
+++ b/source/ITab/ITab_Restrict.cs
@@ -17,7 +17,7 @@ namespace StockpileForDisaster
             {
                 tabDef = DefDatabase<ITab_RestrictDef>.GetNamed("tabSettings");
                 this.size = new Vector2(tabDef.areaSize.x, tabDef.areaSize.y);
-                this.labelKey = "ITabRestrict".Translate();
+                this.labelKey = "ITabRestrict";
                 this.tutorTag = "Restrict";
             });
         }


### PR DESCRIPTION
The labelKey should not be translated.  It should be only the "key."

Currently, the ITab label looks kinda funny; this should fix it.

Thanks for the mod!